### PR TITLE
Fix for redmine bug 1737

### DIFF
--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -108,8 +108,6 @@ TmEcode DecodePcapFileThreadDeinit(ThreadVars *tv, void *data);
 
 void TmModuleReceivePcapFileRegister (void)
 {
-    memset(&pcap_g, 0x00, sizeof(pcap_g));
-
     tmm_modules[TMM_RECEIVEPCAPFILE].name = "ReceivePcapFile";
     tmm_modules[TMM_RECEIVEPCAPFILE].ThreadInit = ReceivePcapFileThreadInit;
     tmm_modules[TMM_RECEIVEPCAPFILE].Func = NULL;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -136,6 +136,7 @@ void TmModuleDecodePcapFileRegister (void)
 
 void PcapFileGlobalInit()
 {
+    memset(&pcap_g, 0x00, sizeof(pcap_g));
     SC_ATOMIC_INIT(pcap_g.invalid_checksums);
 }
 


### PR DESCRIPTION
PCAP stats not reset between files in Unix socket mode. Added a memset to the Global Init function to clear these stats.
